### PR TITLE
Fix sibling product image and feature display

### DIFF
--- a/assets/component-product.css
+++ b/assets/component-product.css
@@ -1292,3 +1292,175 @@ body.layout_rtl .productView-groupTop {
       padding-right: 15px;
   }
 }
+
+/* Sibling Products Styles */
+.productView-siblingProducts {
+  padding-top: var(--spacing-top);
+  padding-bottom: var(--spacing-bottom);
+}
+
+.productView-siblingProducts-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--heading-text-color);
+  margin-bottom: 20px;
+  text-align: left;
+}
+
+.productView-siblingProducts-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+  margin: 0;
+}
+
+.productView-siblingProduct-item {
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  transition: all 0.3s ease;
+  border: 1px solid #f0f0f0;
+}
+
+.productView-siblingProduct-item:hover {
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  transform: translateY(-2px);
+}
+
+.productView-siblingProduct-image {
+  position: relative;
+  overflow: hidden;
+}
+
+.productView-siblingProduct-link {
+  display: block;
+  text-decoration: none;
+}
+
+.productView-siblingProduct-imageWrapper {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  background-color: #f8f8f8;
+}
+
+.productView-siblingProduct-imageWrapper--square {
+  aspect-ratio: 1 / 1;
+}
+
+.productView-siblingProduct-imageWrapper--portrait {
+  aspect-ratio: 3 / 4;
+}
+
+.productView-siblingProduct-imageWrapper--landscape {
+  aspect-ratio: 4 / 3;
+}
+
+.productView-siblingProduct-imageWrapper--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.productView-siblingProduct-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.productView-siblingProduct-item:hover .productView-siblingProduct-img {
+  transform: scale(1.05);
+}
+
+.productView-siblingProduct-info {
+  padding: 15px;
+}
+
+.productView-siblingProduct-vendor {
+  font-size: 12px;
+  color: #888;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 5px;
+}
+
+.productView-siblingProduct-title {
+  margin: 0 0 10px 0;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.productView-siblingProduct-title a {
+  color: var(--heading-text-color);
+  text-decoration: none;
+  transition: color 0.3s ease;
+}
+
+.productView-siblingProduct-title a:hover {
+  color: var(--accent-color, #007bff);
+}
+
+.productView-siblingProduct-price {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+}
+
+.productView-siblingProduct-price-compare {
+  color: #999;
+  text-decoration: line-through;
+  font-size: 12px;
+  font-weight: 400;
+}
+
+.productView-siblingProduct-price-current {
+  color: var(--heading-text-color);
+  font-size: 14px;
+}
+
+/* Responsive Design */
+@media (max-width: 1199px) {
+  .productView-siblingProducts-grid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 15px;
+  }
+}
+
+@media (max-width: 767px) {
+  .productView-siblingProducts-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+  }
+  
+  .productView-siblingProducts-title {
+    font-size: 16px;
+    margin-bottom: 15px;
+  }
+  
+  .productView-siblingProduct-info {
+    padding: 10px;
+  }
+  
+  .productView-siblingProduct-title {
+    font-size: 13px;
+    margin-bottom: 8px;
+  }
+  
+  .productView-siblingProduct-price-current {
+    font-size: 13px;
+  }
+}
+
+@media (max-width: 480px) {
+  .productView-siblingProducts-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 8px;
+  }
+  
+  .productView-siblingProduct-info {
+    padding: 8px;
+  }
+}

--- a/snippets/product-sibling-products.liquid
+++ b/snippets/product-sibling-products.liquid
@@ -36,11 +36,19 @@
                         <a href="{{ sibling_product.url }}" class="productView-siblingProduct-link">
                             {%- if sibling_product.featured_media -%}
                                 <div class="productView-siblingProduct-imageWrapper productView-siblingProduct-imageWrapper--{{ sibling_products_image_ratio }}">
+                                    {%- liquid
+                                        assign image_url = sibling_product.featured_media | image_url: width: 400
+                                        if image_url == blank
+                                            assign image_url = sibling_product.featured_media | img_url: '400x400'
+                                        endif
+                                    -%}
                                     <img 
-                                        src="{{ sibling_product.featured_media | img_url: '300x300' }}"
-                                        alt="{{ sibling_product.featured_media.alt | escape }}"
+                                        src="{{ image_url }}"
+                                        alt="{{ sibling_product.featured_media.alt | default: sibling_product.title | escape }}"
                                         loading="lazy"
                                         class="productView-siblingProduct-img"
+                                        width="400"
+                                        height="400"
                                     />
                                 </div>
                             {%- else -%}

--- a/templates/product.json
+++ b/templates/product.json
@@ -1,12 +1,3 @@
-/*
- * ------------------------------------------------------------
- * IMPORTANT: The contents of this file are auto-generated.
- *
- * This file may be updated by the Shopify admin theme editor
- * or related systems. Please exercise caution as any changes
- * made to this file may be overwritten.
- * ------------------------------------------------------------
- */
 {
   "sections": {
     "main": {
@@ -305,6 +296,20 @@
             "spacing_top": 0,
             "spacing_bottom": 0
           }
+        },
+        "sibling-products-block": {
+          "type": "sibling_products",
+          "settings": {
+            "sibling_products_title": "Related Products",
+            "sibling_products_source": "collection",
+            "sibling_products_collection": "",
+            "sibling_products_limit": 4,
+            "sibling_products_image_ratio": "square",
+            "show_sibling_products_price": true,
+            "show_sibling_products_vendor": false,
+            "spacing_top": 30,
+            "spacing_bottom": 30
+          }
         }
       },
       "block_order": [
@@ -331,7 +336,8 @@
         "dc4b6986-e274-47d6-bc63-d9deab6211d7",
         "c308b6ed-926b-44c6-abd4-ea5bc0cdf499",
         "928ca58c-976c-4d1f-88d0-fff5456d2cf5",
-        "a2dc0e06-db32-4ce9-bc95-f6ab0ae9a032"
+        "a2dc0e06-db32-4ce9-bc95-f6ab0ae9a032",
+        "sibling-products-block"
       ],
       "settings": {
         "container": "container",


### PR DESCRIPTION
Add CSS, update image URL filter, and integrate the sibling products block to fix the display of sibling product images and features.

The sibling products were not displaying correctly due to missing CSS styles, an outdated image URL filter (`img_url` instead of `image_url`), and the sibling products block not being included in the main product template.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d87e1c6-0b72-4819-95a0-2d6147766979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5d87e1c6-0b72-4819-95a0-2d6147766979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

