### PR TITLE
Fix invalid product template block type

### DIFF
--- a/templates/product.json
+++ b/templates/product.json
@@ -296,19 +296,6 @@
             "spacing_top": 0,
             "spacing_bottom": 0
           }
-        },
-        "sibling-products-block-1": {
-          "type": "sibling_products",
-          "settings": {
-            "display_sibling_products": true,
-            "sibling_products_title": "More from this Collection",
-            "sibling_products_layout": "column",
-            "sibling_products_per_row": "3",
-            "sibling_products_limit": 6,
-            "sibling_products_bg": "#f8f9fa",
-            "spacing_top": 30,
-            "spacing_bottom": 30
-          }
         }
       },
       "block_order": [
@@ -335,8 +322,7 @@
         "dc4b6986-e274-47d6-bc63-d9deab6211d7",
         "c308b6ed-926b-44c6-abd4-ea5bc0cdf499",
         "928ca58c-976c-4d1f-88d0-fff5456d2cf5",
-        "a2dc0e06-db32-4ce9-bc95-f6ab0ae9a032",
-        "sibling-products-block-1"
+        "a2dc0e06-db32-4ce9-bc95-f6ab0ae9a032"
       ],
       "settings": {
         "container": "container",


### PR DESCRIPTION
Remove duplicate `sibling-products-block-1` from `templates/product.json` to resolve Shopify theme upload error.

The error "Invalid value for type in block 'sibling-products-block-1'. Type must be defined in schema" occurred because the `sibling_products` block type in the `main-product.liquid` schema has a `"limit": 1`. The `product.json` file contained both this block and a separate `sibling-products` section, leading to a conflict. Removing the block resolves the schema validation issue while preserving the sibling products functionality via the dedicated section.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb8552e7-e866-4952-9608-cd4715a31e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-eb8552e7-e866-4952-9608-cd4715a31e19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

