### PR TITLE
Clean up product sibling data

### DIFF
--- a/templates/product.json
+++ b/templates/product.json
@@ -396,29 +396,6 @@
         "product_block_show": "4"
       }
     },
-    "sibling-products-section": {
-      "type": "sibling-products",
-      "settings": {
-        "display_sibling_products": true,
-        "sibling_products_container": "container",
-        "mg_top_desktop": 50,
-        "mg_top_tablet": 40,
-        "mg_top_mobile": 25,
-        "mg_bottom_desktop": 50,
-        "mg_bottom_tablet": 40,
-        "mg_bottom_mobile": 25,
-        "sibling_products_layout": "column",
-        "sibling_products_bg": "#ffffff",
-        "sibling_products_title": "More from this Collection",
-        "mg_bottom_title": 30,
-        "mg_bottom_title_mb": 20,
-        "sibling_products_title_align": "left",
-        "sibling_products_per_row": "3",
-        "layout_tablet": "2",
-        "layout_mobile": "1",
-        "sibling_products_limit": 6
-      }
-    },
     "81f96038-c0fc-469c-ab0f-a40188c35ccf": {
       "type": "product-recently-viewed",
       "settings": {
@@ -452,7 +429,6 @@
   "order": [
     "main",
     "230c8963-3d40-452c-bca2-5f25b2b533b3",
-    "sibling-products-section",
     "81f96038-c0fc-469c-ab0f-a40188c35ccf"
   ]
 }


### PR DESCRIPTION
Remove the standalone sibling products section from the product page to only display sibling products within the product information block.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c96dcf6-5aa3-4a51-bf5a-e62be247f0a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2c96dcf6-5aa3-4a51-bf5a-e62be247f0a6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

