### PR TITLE
Adjust product block size in column layout

### DIFF
--- a/assets/component-sibling-products.css
+++ b/assets/component-sibling-products.css
@@ -27,6 +27,16 @@
   max-width: 100%;
 }
 
+/* Dynamic sizing support for column layout */
+.sibling-products-column.custom-width {
+  max-width: var(--column-item-width, 400px);
+}
+
+.sibling-products-column.custom-width .product {
+  width: var(--column-item-width, 400px);
+  min-height: var(--column-item-height, 120px);
+}
+
 .sibling-products-column .product {
   border: 1px solid #e9e9e9;
   border-radius: 8px;
@@ -253,6 +263,16 @@
   }
   .sibling-products-grid.column-mb-2 {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  /* Mobile responsive sizing for column layout */
+  .sibling-products-column.custom-width {
+    max-width: calc(var(--column-item-width, 400px) * 0.8);
+  }
+
+  .sibling-products-column.custom-width .product {
+    width: calc(var(--column-item-width, 400px) * 0.8);
+    min-height: calc(var(--column-item-height, 120px) * 0.8);
   }
 }
 

--- a/sections/sibling-products.liquid
+++ b/sections/sibling-products.liquid
@@ -18,6 +18,9 @@
         assign mg_bottom_title = section.settings.mg_bottom_title
         assign mg_bottom_title_mb = section.settings.mg_bottom_title_mb
         
+        assign column_item_width = section.settings.column_item_width
+        assign column_item_height = section.settings.column_item_height
+        
         assign sibling_products = blank
         assign current_product_collections = product.collections
         
@@ -47,6 +50,8 @@
     <style type="text/css" media="screen">
         .section-block-{{section.id}} {
             background-color: {{ section.settings.sibling_products_bg }};
+            --column-item-width: {{ column_item_width | append: 'px' }};
+            --column-item-height: {{ column_item_height | append: 'px' }};
         }
         
         .section-block-{{section.id}} .scoder-block-header .title {
@@ -57,6 +62,7 @@
             display: flex;
             flex-direction: column;
             gap: 20px;
+            max-width: {{ column_item_width | append: 'px' }};
         }
         
         .sibling-products-column .product {
@@ -68,6 +74,8 @@
             display: flex;
             align-items: center;
             padding: 15px;
+            width: {{ column_item_width | append: 'px' }};
+            min-height: {{ column_item_height | append: 'px' }};
         }
         
         .sibling-products-column .product:hover {
@@ -121,10 +129,13 @@
         @media (max-width: 767px) {
             .sibling-products-column {
                 gap: 15px;
+                max-width: calc({{ column_item_width }} * 0.8px);
             }
             
             .sibling-products-column .product {
                 padding: 12px;
+                width: calc({{ column_item_width }} * 0.8px);
+                min-height: calc({{ column_item_height }} * 0.8px);
             }
             
             .sibling-products-column .product .card-product {
@@ -183,7 +194,7 @@
                 
                 <div class="scoder-block-content">
                     {%- if layout == 'column' -%}
-                        <div class="sibling-products-column">
+                        <div class="sibling-products-column custom-width">
                             {%- assign displayed_count = 0 -%}
                             {%- for sibling_product in sibling_products -%}
                                 {%- if sibling_product.id != product.id and displayed_count < limit -%}
@@ -402,6 +413,32 @@
                 }
             ],
             "default": "left"
+        },
+        {
+            "type": "header",
+            "content": "Column Layout Settings"
+        },
+        {
+            "type": "range",
+            "id": "column_item_width",
+            "label": "Item Width (Column Layout)",
+            "min": 200,
+            "max": 800,
+            "step": 10,
+            "unit": "px",
+            "default": 400,
+            "info": "Width of each product item in column layout"
+        },
+        {
+            "type": "range",
+            "id": "column_item_height",
+            "label": "Item Height (Column Layout)",
+            "min": 80,
+            "max": 200,
+            "step": 5,
+            "unit": "px",
+            "default": 120,
+            "info": "Height of each product item in column layout"
         },
         {
             "type": "header",


### PR DESCRIPTION
Add width and height controls for sibling product items in column layout to enable merchant customization.

---
<a href="https://cursor.com/background-agent?bcId=bc-f22f627a-d442-41f0-9221-75fb13f3f622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f22f627a-d442-41f0-9221-75fb13f3f622"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

