### PR TITLE
Increase sibling product image width in theme editor

### DIFF
--- a/assets/component-sibling-products.css
+++ b/assets/component-sibling-products.css
@@ -80,8 +80,8 @@
 
 .sibling-product-card .card-product__media {
   flex-shrink: 0;
-  width: 80px;
-  height: 80px;
+  width: var(--sibling-image-width, 80px);
+  height: var(--sibling-image-height, 80px);
   border-radius: 6px;
   overflow: hidden;
   position: relative;
@@ -246,8 +246,8 @@
   }
 
   .sibling-product-card .card-product__media {
-    width: 60px;
-    height: 60px;
+    width: calc(var(--sibling-image-width, 80px) * 0.85);
+    height: calc(var(--sibling-image-height, 80px) * 0.85);
   }
 
   .sibling-product-card .card-product__title {

--- a/sections/main-product.liquid
+++ b/sections/main-product.liquid
@@ -2106,6 +2106,32 @@
         },
         {
           "type": "header",
+          "content": "Image Settings"
+        },
+        {
+          "type": "range",
+          "id": "sibling_product_image_width",
+          "label": "Product Image Width",
+          "min": 40,
+          "max": 120,
+          "step": 5,
+          "unit": "px",
+          "default": 60,
+          "info": "Width of the product image in sibling products"
+        },
+        {
+          "type": "range",
+          "id": "sibling_product_image_height",
+          "label": "Product Image Height",
+          "min": 40,
+          "max": 120,
+          "step": 5,
+          "unit": "px",
+          "default": 60,
+          "info": "Height of the product image in sibling products"
+        },
+        {
+          "type": "header",
           "content": "Spacing"
         },
         {

--- a/sections/sibling-products.liquid
+++ b/sections/sibling-products.liquid
@@ -20,6 +20,8 @@
 
     assign column_item_width = section.settings.column_item_width
     assign column_item_height = section.settings.column_item_height
+    assign image_width = section.settings.sibling_product_image_width | default: 80
+    assign image_height = section.settings.sibling_product_image_height | default: 80
 
     assign sibling_products = blank
     assign current_product_collections = product.collections
@@ -52,6 +54,8 @@
         background-color: {{ section.settings.sibling_products_bg }};
         --column-item-width: {{ column_item_width | append: 'px' }};
         --column-item-height: {{ column_item_height | append: 'px' }};
+        --sibling-image-width: {{ image_width | append: 'px' }};
+        --sibling-image-height: {{ image_height | append: 'px' }};
     }
 
     .section-block-{{section.id}} .scoder-block-header .title {
@@ -209,7 +213,9 @@
                       show_vendor: false,
                       show_rating: false,
                       show_quick_add: false,
-                      placeholder_index: forloop.index
+                      placeholder_index: forloop.index,
+                      image_width: image_width,
+                      image_height: image_height
                     %}
                   </div>
                   {%- assign displayed_count = displayed_count | plus: 1 -%}
@@ -442,6 +448,28 @@
       "unit": "px",
       "default": 120,
       "info": "Height of each product item in column layout"
+    },
+    {
+      "type": "range",
+      "id": "sibling_product_image_width",
+      "label": "Product Image Width",
+      "min": 40,
+      "max": 120,
+      "step": 5,
+      "unit": "px",
+      "default": 80,
+      "info": "Width of the product image in sibling products"
+    },
+    {
+      "type": "range",
+      "id": "sibling_product_image_height",
+      "label": "Product Image Height",
+      "min": 40,
+      "max": 120,
+      "step": 5,
+      "unit": "px",
+      "default": 80,
+      "info": "Height of the product image in sibling products"
     },
     {
       "type": "header",

--- a/snippets/sibling-product-card.liquid
+++ b/snippets/sibling-product-card.liquid
@@ -8,6 +8,8 @@
     assign lazy_load = lazy_load | default: true
     assign show_secondary_image = show_secondary_image | default: false
     assign placeholder_index = placeholder_index | default: 1
+    assign image_width = image_width | default: 60
+    assign image_height = image_height | default: 60
 -%}
 
 <div class="card-product sibling-product-card" data-product-id="{{ product_card_product.id }}">
@@ -21,7 +23,7 @@
                         {{ product_card_product.featured_media | image_url }} {{ product_card_product.featured_media.width }}w
                     "
                     src="{{ product_card_product.featured_media | image_url: width: 330 }}"
-                    sizes="(min-width: 1200px) 80px, (min-width: 768px) 80px, 60px"
+                    sizes="(min-width: 1200px) {{ image_width }}px, (min-width: 768px) {{ image_width }}px, {{ image_width | times: 0.85 | round }}px"
                     alt="{{ product_card_product.featured_media.alt | escape }}"
                     class="card-product__image"
                     loading="lazy"

--- a/snippets/sibling-products-block.liquid
+++ b/snippets/sibling-products-block.liquid
@@ -6,6 +6,8 @@
     assign block_title = block.settings.sibling_products_title
     assign column = block.settings.sibling_products_per_row
     assign selected_collection = block.settings.sibling_products_collection
+    assign image_width = block.settings.sibling_product_image_width | default: 60
+    assign image_height = block.settings.sibling_product_image_height | default: 60
     
     assign sibling_products = blank
     
@@ -44,6 +46,8 @@
         padding-bottom: var(--spacing-bottom);
         margin-top: 20px;
         border-radius: 8px;
+        --sibling-image-width: {{ image_width }}px;
+        --sibling-image-height: {{ image_height }}px;
     }
     
     .sibling-products-block .sibling-products-title {
@@ -85,8 +89,8 @@
     
     .sibling-products-column .product .card-product__media {
         flex-shrink: 0;
-        width: 60px;
-        height: 60px;
+        width: var(--sibling-image-width);
+        height: var(--sibling-image-height);
     }
     
     .sibling-products-column .product .card-product__content {
@@ -143,8 +147,8 @@
         }
         
         .sibling-products-column .product .card-product__media {
-            width: 50px;
-            height: 50px;
+            width: calc(var(--sibling-image-width) * 0.85);
+            height: calc(var(--sibling-image-height) * 0.85);
         }
         
         .sibling-products-column .product .card-product__title {
@@ -183,7 +187,9 @@
                                 show_vendor: false,
                                 show_rating: false,
                                 show_quick_add: false,
-                                placeholder_index: forloop.index
+                                placeholder_index: forloop.index,
+                                image_width: image_width,
+                                image_height: image_height
                             %}
                         </div>
                         {%- assign displayed_count = displayed_count | plus: 1 -%}


### PR DESCRIPTION
Add image width and height settings to sibling product blocks and sections to allow customization via the theme editor.

---
<a href="https://cursor.com/background-agent?bcId=bc-09e0e3fe-35bb-4976-9a44-edde9d1c370f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09e0e3fe-35bb-4976-9a44-edde9d1c370f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

